### PR TITLE
feat: Criação de acesso e validação na tela de login

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.example.freela" />
+                  <option name="mobileSdkAppId" value="1:50862841807:android:6f6f8a68e51d6872e47cba" />
+                  <option name="projectId" value="freela-999a9" />
+                  <option name="projectNumber" value="50862841807" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.kotlin/errors/errors-1761681641137.log
+++ b/.kotlin/errors/errors-1761681641137.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -54,4 +55,13 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit.gson)
     implementation(libs.androidx.recyclerview)
+
+    // Firebase (BOM = controla versões)
+    implementation(platform("com.google.firebase:firebase-bom:34.4.0"))
+    implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.firebase:firebase-analytics")
+
+    // Coroutines (necessário para suspendCancellableCoroutine)
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "50862841807",
+    "project_id": "freela-999a9",
+    "storage_bucket": "freela-999a9.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:50862841807:android:6f6f8a68e51d6872e47cba",
+        "android_client_info": {
+          "package_name": "com.example.freela"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA7oDS8N_OjxkHsJEzkBZ_KAuKSaJRSDKY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/example/freela/domain/usecase/LoginUseCase.kt
+++ b/app/src/main/java/com/example/freela/domain/usecase/LoginUseCase.kt
@@ -1,0 +1,7 @@
+package com.example.freela.domain.usecase
+
+import com.example.freela.repository.auth.AuthRepository
+
+class LoginUseCase(private val repository: AuthRepository) {
+    suspend operator fun invoke(email: String, password: String) = repository.login(email, password)
+}

--- a/app/src/main/java/com/example/freela/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/freela/repository/auth/AuthRepository.kt
@@ -1,0 +1,31 @@
+package com.example.freela.repository.auth
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+class AuthRepository(private val auth: FirebaseAuth) {
+
+    suspend fun login(email: String, password: String): Result<Unit> =
+        try {
+            suspendCancellableCoroutine { cont ->
+                auth.signInWithEmailAndPassword(email, password)
+                    .addOnCompleteListener { task ->
+                        if (task.isSuccessful) {
+                            cont.resume(Result.success(Unit))
+                        } else {
+                            val e = task.exception
+                            if (e is FirebaseAuthException) {
+                                cont.resume(Result.failure(e))
+                            } else {
+                                cont.resume(Result.failure(Exception("Erro desconhecido")))
+                            }
+                        }
+                    }
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+}

--- a/app/src/main/java/com/example/freela/viewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/freela/viewModel/LoginViewModel.kt
@@ -1,0 +1,26 @@
+package com.example.freela.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.freela.domain.usecase.LoginUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class LoginViewModel(private val loginUseCase: LoginUseCase) : ViewModel() {
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> get() = _loading
+
+    private val _loginResult = MutableStateFlow<Result<Unit>?>(null)
+    val loginResult: StateFlow<Result<Unit>?> get() = _loginResult
+
+    fun login(email: String, password: String) {
+        viewModelScope.launch {
+            _loading.value = true
+            val result = loginUseCase(email, password)
+            _loginResult.value = result
+            _loading.value = false
+        }
+    }
+}

--- a/app/src/main/java/com/example/freela/viewModel/LoginViewModelFactory.kt
+++ b/app/src/main/java/com/example/freela/viewModel/LoginViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.example.freela.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.freela.domain.usecase.LoginUseCase
+import com.example.freela.viewModel.LoginViewModel
+
+class LoginViewModelFactory(
+    private val loginUseCase: LoginUseCase
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return LoginViewModel(loginUseCase) as T
+    }
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
+
+    <TextView
+        android:id="@+id/tvSuccess"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Logado com sucesso"
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -32,27 +32,31 @@
         android:layout_width="100dp"
         android:layout_height="100dp"
         android:layout_marginTop="80dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginBottom="67dp"
+        android:contentDescription="Logo"
+        app:layout_constraintBottom_toBottomOf="@+id/blueHeader"
         app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@drawable/group_4___logo1"
-        android:contentDescription="Logo" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/group_4___logo1" />
 
     <TextView
         android:id="@+id/tvWelcome"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Bem-vindo de volta!"
+        android:layout_marginTop="105dp"
+        android:layout_marginBottom="90dp"
+        android:text="@string/welcomeback"
         android:textColor="@color/blue"
         android:textSize="22sp"
         android:textStyle="bold"
-        android:layout_marginTop="260dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/inputEmail"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/imageLogo" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/inputCpf"
+        android:id="@+id/inputEmail"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -63,18 +67,19 @@
         app:layout_constraintEnd_toEndOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etEmail"
             android:background="@drawable/bg_input_secundary"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="CPF"
+            android:hint="Email"
             android:padding="12dp"
-            android:inputType="number"
+            android:inputType="textEmailAddress"
             android:drawableEnd="@drawable/check"
             android:drawablePadding="20dp"/>
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/inputSenha"
+        android:id="@+id/inputPassword"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -82,11 +87,12 @@
         android:layout_marginTop="15dp"
         android:contentDescription="@string/password_field"
         app:startIconDrawable="@drawable/ic_lock"
-        app:layout_constraintTop_toBottomOf="@id/inputCpf"
+        app:layout_constraintTop_toBottomOf="@id/inputEmail"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etPassword"
             android:layout_width="match_parent"
             android:layout_height="50dp"
             android:background="@drawable/bg_input_primary"
@@ -101,30 +107,42 @@
         android:id="@+id/tvForgotPassword"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="30dp"
         android:text="Esqueci a senha"
         android:textColor="@color/blue"
         android:textSize="14sp"
-        app:layout_constraintTop_toBottomOf="@id/inputSenha"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginEnd="30dp"
-        android:layout_marginTop="8dp" />
+        app:layout_constraintTop_toBottomOf="@id/inputPassword" />
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btnEntrar"
+        android:id="@+id/btnLogin"
+        style="@style/button_primary_style"
         android:layout_width="0dp"
         android:layout_height="55dp"
         android:layout_marginStart="30dp"
-        android:layout_marginTop="25dp"
+        android:layout_marginTop="89dp"
         android:layout_marginEnd="30dp"
-        style="@style/button_primary_style"
+        android:layout_marginBottom="113dp"
         android:elevation="6dp"
         android:text="Entrar"
+        app:layout_constraintBottom_toTopOf="@+id/tvRegister"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tvForgotPassword" />
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/tvRegister"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="20dp"/>
+
     <TextView
-        android:id="@+id/tvCadastro"
+        android:id="@+id/tvRegister"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="113dp"
@@ -134,6 +152,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnEntrar" />
+        app:layout_constraintTop_toBottomOf="@+id/progressBar" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="register_password_confirmar_email">Confirmar E-mail</string>
     <string name="password_field">Campo de Senha</string>
     <string name="register_address_complemento">Complemento</string>
+    <string name="fill_all_fields">Preencha todos os campos</string>
+    <string name="unexpected_error">Ocorreu um erro inesperado</string>
     <string name="new_user">
     <font color="#050505">Novo usuário?</font> <font color="#0451FF">Cadastre-se</font>
 </string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
+    id("com.google.gms.google-services") version "4.4.4" apply false
 }


### PR DESCRIPTION
1. Validação local antes de chamar o Firebase

Antes de disparar a autenticação, validamos no próprio app, email não vazio e formato válido, mostrando mensagens se o campo for inválido (pra evitar chamadas desnecessárias à rede).

2. Use cases no domínio

Foi criado um LoginUseCase dentro de domain/usecase, tipo:

Separa a lógica de negócio (login, regras) da lógica de interface (telas).
O ViewModel só orquestra, e o Activity só observa.

3. Tratamento refinado dos erros

Firebase lança exceções genéricas, foi mapeado essas exceções no repository, pra retornar algo legível

4.  Loading state bem controlado

Durante o login, é mostrado um ProgressBar e desabilitado o botão “Entrar”.
Isso evita múltiplos cliques e requisições concorrentes.

5. Arquitetura:

LoginActivity > apenas input + observação.

LoginViewModel > chama LoginUseCase.

LoginUseCase > chama AuthRepository.

AuthRepository > comunica com FirebaseAuth.
